### PR TITLE
Use ruby 3.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# the Ubuntu version of base image is 22.04.1 LTS
-# https://circleci.com/developer/images/image/cimg/ruby
-FROM cimg/ruby:3.2.2-browsers
+FROM --platform=linux/amd64 cimg/ruby:3.3.1-browsers
 
 USER root
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Set `--platform` to build docker image on Apple Silicon Mac. 
The platform of Apple Silicon Mac is `linux/arm64`, which is not supported by CircleCI Ruby images.